### PR TITLE
Add an `e` to `pipline`.

### DIFF
--- a/resources/google-deployments/cromwell.yaml
+++ b/resources/google-deployments/cromwell.yaml
@@ -21,7 +21,7 @@ resources:
       cromwell_cloudsql_password:      <PASSWORD>
 
       labels:
-        user:    <USER>
-        project: <PROJECT>
-        pipline: <PIPELINE>
+        user:     <USER>
+        project:  <PROJECT>
+        pipeline: <PIPELINE>
 # [END cromwell_yaml]


### PR DESCRIPTION
Either one could be a valid label, I suppose!