### PR TITLE
Type of `labels` should be `object` and not `dict`.

### DIFF
--- a/resources/google-deployments/cromwell.jinja.schema
+++ b/resources/google-deployments/cromwell.jinja.schema
@@ -52,7 +52,7 @@ properties:
 
     labels:
       description: Labels to apply to the compute and cloud sql instances.
-      type: dict
+      type: object
 
     region:
       type: string


### PR DESCRIPTION
Google complains about:
```
  message: |-
    Manifest expansion encountered the following errors: Invalid schema 'cromwell.jinja.schema':
    'dict' is not valid under any of the given schemas at [u'properties', 'labels', u'type']
     Resource: cromwell Resource: config
```
The Internet told me that the type in JSON is called `object` instead.  (Google does support python templates instead of jinja ones if we prefer!) 