### PR TITLE
Generalize to be usable by other GCP projects

### DIFF
--- a/resources/cromwell-configs/PAPI.v2.conf
+++ b/resources/cromwell-configs/PAPI.v2.conf
@@ -46,13 +46,13 @@ system {
 
   # Default number of cache read workers
   number-of-cache-read-workers = 25
-  
+
   io {
     # Global Throttling - This is mostly useful for GCS and can be adjusted to match
     # the quota availble on the GCS API
     number-of-requests = 100000
     per = 100 seconds
-    
+
     # Number of times an I/O operation should be attempted before giving up and failing it.
     number-of-attempts = 50
   }
@@ -126,7 +126,7 @@ engine {
      #project = "google-billing-project"
     }
     local {
-      enabled: true      
+      enabled: true
     }
   }
 }
@@ -140,9 +140,8 @@ backend {
       config {
         # Google project
         # TODO - We may not want to set these in the config and instead force them to be set on server instantiation or with workflow options.
-        project = "washu-genome-inh-dis-analysis"
-        root = "gs://wustl-ccdg-cromwell-processing/cromwell-executions"
-    
+        project = {{ project }}
+        root = "{{ cromwell_gcs_root }}"
         # Set this to the lower of the two values "Queries per 100 seconds" and "Queries per 100 seconds per user" for
         # your project.
         #
@@ -151,37 +150,37 @@ backend {
         # 1000 is the default "Queries per 100 seconds per user", 50000 is the default "Queries per 100 seconds"
         # See https://cloud.google.com/genomics/quotas for more information
         genomics-api-queries-per-100-seconds = 1000
-    
+
         # Polling for completion backs-off gradually for slower-running jobs.
         # This is the maximum polling interval (in seconds):
         maximum-polling-interval = 600
-    
+
         genomics {
           # A reference to an auth defined in the `google` stanza at the top.  This auth is used to create
           # Pipelines and manipulate auth JSONs.
           auth = "application-default"
-    
-    
+
+
           # alternative service account to use on the launched compute instance
           # NOTE: If combined with service account authorization, both that serivce account and this service account
           # must be able to read and write to the 'root' GCS path
           # FIXME MGI APPLY FROM DEPLOYMENT CONFIG
-          compute-service-account = "hall-lab-cromwell-executor@washu-genome-inh-dis-analysis.iam.gserviceaccount.com"
-    
+          compute-service-account = "{{ service_account_email }}"
+
           # Endpoint for APIs, no reason to change this unless directed by Google.
           endpoint-url = "https://genomics.googleapis.com/"
         }
-    
+
         filesystems {
           gcs {
             # A reference to a potentially different auth for manipulating files via engine functions.
             auth = "application-default"
-	    caching {
+            caching {
               duplication-strategy = "reference"
             }
           }
         }
-    
+
       }
     }
   }

--- a/resources/google-deployments/cromwell.jinja
+++ b/resources/google-deployments/cromwell.jinja
@@ -69,6 +69,23 @@ resources:
     dependsOn:
       - {{ staticIpName }}
 
+- name: cromwell
+  type: gcp-types/sqladmin-v1beta4:databases
+  properties:
+    name: cromwell
+    instance: $(ref.{{ cloudsqlName }}.name)
+    charset: utf8
+- name: root-user-entity
+  type: gcp-types/sqladmin-v1beta4:users
+  properties:
+    instance: $(ref.{{ cloudsqlName }}.name)
+    name: root
+    host: "%"
+    password: {{ properties["cromwell_cloudsql_password"] }}
+  metadata:
+    dependsOn:
+      - cromwell
+
 - name: {{ cromwellServerName }}
   type: compute.v1.instance
   properties:

--- a/resources/google-deployments/cromwell.jinja
+++ b/resources/google-deployments/cromwell.jinja
@@ -110,7 +110,7 @@ resources:
       items:
         - key: startup-script
           value: |
-            {{ imports["../startup-scripts/cromwell.py"]|indent(12)|replace("@CROMWELL_VERSION@",properties["cromwell_version"])|replace("@CROMWELL_CLOUDSQL_PASSWORD@",properties["cromwell_cloudsql_password"]) }}
+            {{ imports["../startup-scripts/cromwell.py"]|indent(12)|replace("@CROMWELL_VERSION@",properties["cromwell_version"])|replace("@CROMWELL_CLOUDSQL_PASSWORD@",properties["cromwell_cloudsql_password"])|replace("@SERVICE_ACCOUNT_EMAIL@",properties["service_account_email"])|replace("@PROJECT@",env["project"])|replace("@CROMWELL_GCS_ROOT@",properties["cromwell_gcs_root"]) }}
         - key: cromwell-service
           value: |
             {{ imports["../cromwell-configs/systemd/cromwell.service"]|indent(12)|replace("@CROMWELL_VERSION@",properties["cromwell_version"])|replace("@CROMWELL_CLOUDSQL_PASSWORD@",properties["cromwell_cloudsql_password"])|replace("@CROMWELL_SERVER_SERVICE_MEM@",properties["cromwell_server_service_mem"]) }}

--- a/resources/google-deployments/cromwell.yaml
+++ b/resources/google-deployments/cromwell.yaml
@@ -9,7 +9,7 @@ resources:
       # Commented out properties have defaults set in the schema
       region:                          us-central1
       zone:                            us-central1-a
-      service_account_email:           hall-lab-cromwell-executor@washu-genome-inh-dis-analysis.iam.gserviceaccount.com
+      service_account_email:           <SERVICE_ACCOUNT_EMAIL>
       ssh_source_ranges:               [ 0.0.0.0/0 ] # this is ALL IPs
       cromwell_version:                39
       #cromwell_server_machine_type:    n1-standard-8
@@ -20,6 +20,7 @@ resources:
       #cromwell_cloudsql_initial_size:  1000
       #cromwell_database_name:          cromwell
       cromwell_cloudsql_password:      <PASSWORD>
+      cromwell_gcs_root:               "gs://<BUCKET_NAME>/cromwell-exeuctions"
 
       labels:
         user:     <USER>

--- a/resources/startup-scripts/cromwell.py
+++ b/resources/startup-scripts/cromwell.py
@@ -144,23 +144,6 @@ def _fetch_instance_info(name):
 
 #-- _fetch_instance_info
 
-def configure_cromwell_database():
-    sys.stderr.write("Configure cromwell database...\n")
-
-    cloudsql_name = _fetch_instance_info('cloudsql-name')
-    sys.stderr.write("Updating root password...\n")
-    rv = subprocess.call(["gcloud", "sql", "users", "set-password", "root", "--instance", cloudsql_name, "--password", CROMWELL_CLOUDSQL_PASSWORD, "--host", "%"])
-    if rv != 0: raise Exception("Failed to update mysql root user password!")
-
-    cloudsql_ip = _fetch_instance_info('cloudsql-ip')
-    sys.stderr.write("Creating cromwell database...\n")
-    lenv = os.environ.copy()
-    lenv['MYSQL_PWD'] = CROMWELL_CLOUDSQL_PASSWORD
-    rv = subprocess.call(['mysql', '-h', cloudsql_ip, '-u', 'root', '-e', 'CREATE DATABASE IF NOT EXISTS cromwell;'], env=lenv)
-    if rv != 0: raise Exception("Failed to create the mysql cromwell database")
-
-#-- configure_cromwell_database
-
 if __name__ == '__main__':
     create_directories()
     install_packages()
@@ -169,7 +152,6 @@ if __name__ == '__main__':
     install_cromshell()
     add_cromwell_profile()
     add_and_start_cromwell_service()
-    configure_cromwell_database()
     print("Startup script...DONE")
 
 #-- __main__

--- a/resources/startup-scripts/cromwell.py
+++ b/resources/startup-scripts/cromwell.py
@@ -4,6 +4,10 @@ import os, subprocess, sys
 
 CROMWELL_CLOUDSQL_PASSWORD='@CROMWELL_CLOUDSQL_PASSWORD@'
 CROMWELL_VERSION='@CROMWELL_VERSION@'
+CROMWELL_GCS_ROOT='@CROMWELL_GCS_ROOT@'
+SERVICE_ACCOUNT_EMAIL='@SERVICE_ACCOUNT_EMAIL@'
+PROJECT='@PROJECT@'
+
 INSTALL_DIR = os.path.join(os.path.sep, 'opt', 'cromwell')
 BIN_DIR = os.path.join(INSTALL_DIR, "bin")
 JAR_DIR = os.path.join(INSTALL_DIR, "jar")
@@ -85,7 +89,10 @@ def install_cromwell_config():
     ip = _fetch_instance_info(name='cloudsql-ip')
     params = { "ip": ip, "password": CROMWELL_CLOUDSQL_PASSWORD }
     with open(fn, 'w') as f:
-        f.write( papi_template.render(cloudsql=params) )
+        f.write( papi_template.render(cloudsql=params,
+                                      project=PROJECT,
+                                      service_account_EMAIL=SERVICE_ACCOUNT_EMAIL,
+                                      cromwell_gcs_root=CROMWELL_GCS_ROOT) )
 
 #-- install_cromwell_config
 

--- a/resources/startup-scripts/cromwell.py
+++ b/resources/startup-scripts/cromwell.py
@@ -91,7 +91,7 @@ def install_cromwell_config():
     with open(fn, 'w') as f:
         f.write( papi_template.render(cloudsql=params,
                                       project=PROJECT,
-                                      service_account_EMAIL=SERVICE_ACCOUNT_EMAIL,
+                                      service_account_email=SERVICE_ACCOUNT_EMAIL,
                                       cromwell_gcs_root=CROMWELL_GCS_ROOT) )
 
 #-- install_cromwell_config


### PR DESCRIPTION
Changes required to make this resource usable to spin up needed resources for another project/lab.

- Parameterize project values, pulled from `env['project']` in jinja
- Parameterize cromwell_gcs_root, pulled from new properties in yaml
- Propagate service_account_email to PAPI.v2.conf, previously hardcoded

Also ran into the issue where the VM is required to have administrator access to the cloudsql instance to set use passwords and create the db. Moved those definitions up to the yaml so they're done on deployment instead of whenever a VM is spun up, removing that requirement.