### PR TITLE
Upgrade Life Sciences API

### DIFF
--- a/resources/cromwell-configs/PAPI.v2.conf
+++ b/resources/cromwell-configs/PAPI.v2.conf
@@ -190,6 +190,7 @@ backend {
         # See https://cromwell.readthedocs.io/en/stable/backends/Google/ for more details.
         virtual-private-cloud {
           network-name = "{{ vpc_network }}"
+          subnetwork-name = "{{ vpc_subnetwork }}"
         }
         {% endif %}
 

--- a/resources/cromwell-configs/PAPI.v2.conf
+++ b/resources/cromwell-configs/PAPI.v2.conf
@@ -185,6 +185,14 @@ backend {
           }
         }
 
+        {% if vpc_network %}
+        # Optional configuration to use high security network (Virtual Private Cloud) for running jobs.
+        # See https://cromwell.readthedocs.io/en/stable/backends/Google/ for more details.
+        virtual-private-cloud {
+          network-name = "{{ vpc_network }}"
+        }
+        {% endif %}
+
       }
     }
   }
@@ -194,7 +202,7 @@ services {
   MetadataService {
     config {
       # Prevents cromwell from crashing if metadata is too big, and the server does not have enough memory allocated. Default is 1000000.
-      # metadata-read-row-number-safety-threshold = 1000000
+      metadata-read-row-number-safety-threshold = 2000000
       # Set this value to "Inf" to turn off metadata summary refresh.  The default value is currently "2 seconds".
       # metadata-summary-refresh-interval = "Inf"
       # For higher scale environments, e.g. many workflows and/or jobs, DB write performance for metadata events

--- a/resources/cromwell-configs/PAPI.v2.conf
+++ b/resources/cromwell-configs/PAPI.v2.conf
@@ -132,16 +132,17 @@ engine {
 }
 
 backend {
-  default = "JES"
+  default = "PapiV2"
   providers {
-    JES {
+    PapiV2 {
       # NOTE - This is PAPIv2
-      actor-factory = "cromwell.backend.google.pipelines.v2alpha1.PipelinesApiLifecycleActorFactory"
+      actor-factory = "cromwell.backend.google.pipelines.v2beta.PipelinesApiLifecycleActorFactory"
       config {
         # Google project
         # TODO - We may not want to set these in the config and instead force them to be set on server instantiation or with workflow options.
         project = "{{ project }}"
         root = "{{ cromwell_gcs_root }}"
+
         # Set this to the lower of the two values "Queries per 100 seconds" and "Queries per 100 seconds per user" for
         # your project.
         #
@@ -160,15 +161,18 @@ backend {
           # Pipelines and manipulate auth JSONs.
           auth = "application-default"
 
-
           # alternative service account to use on the launched compute instance
           # NOTE: If combined with service account authorization, both that serivce account and this service account
           # must be able to read and write to the 'root' GCS path
           # FIXME MGI APPLY FROM DEPLOYMENT CONFIG
           compute-service-account = "{{ service_account_email }}"
 
+
           # Endpoint for APIs, no reason to change this unless directed by Google.
-          endpoint-url = "https://genomics.googleapis.com/"
+          endpoint-url = "https://lifesciences.googleapis.com/"
+
+          # Currently Cloud Life Sciences API is available only in `us-central1` and `europe-west2` locations.
+          location = "us-central1"
         }
 
         filesystems {

--- a/resources/google-deployments/cromwell.jinja
+++ b/resources/google-deployments/cromwell.jinja
@@ -1,6 +1,11 @@
 
 {% set networkName = env['deployment'] + '-net' %}
 {% set subNetworkName = env['deployment'] + '-subnet' %}
+{% if use_vpc_network %}
+{%   set vpc_network = networkName %}
+{% else %}
+{%   set vpc_network = "" %}
+{% endif %}
 {% set staticIpName = env['deployment'] + '-static-ip' %}
 {% set cromwellServerName = env['deployment'] + '-cromwell' %}
 {% set cloudsqlName = env['deployment'] + '-cloudsql' %}
@@ -127,7 +132,7 @@ resources:
       items:
         - key: startup-script
           value: |
-            {{ imports["../startup-scripts/cromwell.py"]|indent(12)|replace("@CROMWELL_VERSION@",properties["cromwell_version"])|replace("@CROMWELL_CLOUDSQL_PASSWORD@",properties["cromwell_cloudsql_password"])|replace("@SERVICE_ACCOUNT_EMAIL@",properties["service_account_email"])|replace("@PROJECT@",env["project"])|replace("@CROMWELL_GCS_ROOT@",properties["cromwell_gcs_root"]) }}
+            {{ imports["../startup-scripts/cromwell.py"]|indent(12)|replace("@VPC_NETWORK@",vpc_network)|replace("@CROMWELL_VERSION@",properties["cromwell_version"])|replace("@CROMWELL_CLOUDSQL_PASSWORD@",properties["cromwell_cloudsql_password"])|replace("@SERVICE_ACCOUNT_EMAIL@",properties["service_account_email"])|replace("@PROJECT@",env["project"])|replace("@CROMWELL_GCS_ROOT@",properties["cromwell_gcs_root"]) }}
         - key: cromwell-service
           value: |
             {{ imports["../cromwell-configs/systemd/cromwell.service"]|indent(12)|replace("@CROMWELL_VERSION@",properties["cromwell_version"])|replace("@CROMWELL_CLOUDSQL_PASSWORD@",properties["cromwell_cloudsql_password"])|replace("@CROMWELL_SERVER_SERVICE_MEM@",properties["cromwell_server_service_mem"]) }}

--- a/resources/google-deployments/cromwell.jinja
+++ b/resources/google-deployments/cromwell.jinja
@@ -1,7 +1,7 @@
 
 {% set networkName = env['deployment'] + '-net' %}
 {% set subNetworkName = env['deployment'] + '-subnet' %}
-{% if use_vpc_network %}
+{% if properties["use_vpc_network"] %}
 {%   set vpc_network = networkName %}
 {%   set vpc_subnetwork = subNetworkName %}
 {% else %}

--- a/resources/google-deployments/cromwell.jinja
+++ b/resources/google-deployments/cromwell.jinja
@@ -22,6 +22,9 @@ resources:
     network: $(ref.{{ networkName }}.selfLink)
     ipCidrRange: 10.10.0.0/16
     region: {{ properties["region"] }}
+    {% if vpc_network %}
+    privateIpGoogleAccess: true
+    {% endif %}
 
 {% if properties['ssh_source_ranges'] %}
 - name: {{ networkName }}-ssh-allowed

--- a/resources/google-deployments/cromwell.jinja
+++ b/resources/google-deployments/cromwell.jinja
@@ -22,7 +22,7 @@ resources:
   type: compute.v1.subnetwork
   properties:
     network: $(ref.{{ networkName }}.selfLink)
-    ipCidrRange: 10.10.0.0/16
+    ipCidrRange: {{ properties["vpc_cidr"] }}
     region: {{ properties["region"] }}
     {% if vpc_network %}
     privateIpGoogleAccess: true

--- a/resources/google-deployments/cromwell.jinja
+++ b/resources/google-deployments/cromwell.jinja
@@ -3,8 +3,10 @@
 {% set subNetworkName = env['deployment'] + '-subnet' %}
 {% if use_vpc_network %}
 {%   set vpc_network = networkName %}
+{%   set vpc_subnetwork = subNetworkName %}
 {% else %}
 {%   set vpc_network = "" %}
+{%   set vpc_subnetwork = "" %}
 {% endif %}
 {% set staticIpName = env['deployment'] + '-static-ip' %}
 {% set cromwellServerName = env['deployment'] + '-cromwell' %}
@@ -135,7 +137,7 @@ resources:
       items:
         - key: startup-script
           value: |
-            {{ imports["../startup-scripts/cromwell.py"]|indent(12)|replace("@VPC_NETWORK@",vpc_network)|replace("@CROMWELL_VERSION@",properties["cromwell_version"])|replace("@CROMWELL_CLOUDSQL_PASSWORD@",properties["cromwell_cloudsql_password"])|replace("@SERVICE_ACCOUNT_EMAIL@",properties["service_account_email"])|replace("@PROJECT@",env["project"])|replace("@CROMWELL_GCS_ROOT@",properties["cromwell_gcs_root"]) }}
+            {{ imports["../startup-scripts/cromwell.py"]|indent(12)|replace("@VPC_NETWORK@",vpc_network)|replace("@VPC_SUBNETWORK@",vpc_subnetwork)|replace("@CROMWELL_VERSION@",properties["cromwell_version"])|replace("@CROMWELL_CLOUDSQL_PASSWORD@",properties["cromwell_cloudsql_password"])|replace("@SERVICE_ACCOUNT_EMAIL@",properties["service_account_email"])|replace("@PROJECT@",env["project"])|replace("@CROMWELL_GCS_ROOT@",properties["cromwell_gcs_root"]) }}
         - key: cromwell-service
           value: |
             {{ imports["../cromwell-configs/systemd/cromwell.service"]|indent(12)|replace("@CROMWELL_VERSION@",properties["cromwell_version"])|replace("@CROMWELL_CLOUDSQL_PASSWORD@",properties["cromwell_cloudsql_password"])|replace("@CROMWELL_SERVER_SERVICE_MEM@",properties["cromwell_server_service_mem"]) }}

--- a/resources/google-deployments/cromwell.jinja
+++ b/resources/google-deployments/cromwell.jinja
@@ -112,7 +112,7 @@ resources:
         boot: true
         autoDelete: true
         initializeParams:
-          sourceImage: https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/family/debian-9
+          sourceImage: https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/family/debian-10
           diskType: https://www.googleapis.com/compute/v1/projects/{{ env["project"] }}/zones/{{ properties["zone"] }}/diskTypes/pd-standard
           diskSizeGb: {{ properties['cromwell_server_boot_disk_size'] }}
     networkInterfaces:

--- a/resources/google-deployments/cromwell.jinja.schema
+++ b/resources/google-deployments/cromwell.jinja.schema
@@ -15,6 +15,7 @@ required:
 - region
 - service_account_email
 - ssh_source_ranges
+- use_vpc_network
 - zone
 
 properties:
@@ -53,9 +54,8 @@ properties:
       default: 28
 
     cromwell_version:
-      description: Version of cromwell to use.
+      description: Version of cromwell to use. Minimum version is "68_hotfix_8e12ab5"
       type: string
-      minimum: 60
 
     labels:
       description: Labels to apply to the compute and cloud sql instances.
@@ -72,6 +72,11 @@ properties:
     ssh_source_ranges:
       type        : array
       description : Allow SSH access to the cromwell compute instance from a whitelist of IP addresses via a firewall. Use CIDR notation. To allow connections from any IP (not recommended) use "0.0.0.0/0".
+
+    use_vpc_network:
+      description: Have cromwell use the cromwell net created as the VPC network. This will result in all VMs being placed on this network (instead of default) and they will not have public IPs.
+      type: boolean
+      default: false
 
     zone:
       type: string

--- a/resources/google-deployments/cromwell.jinja.schema
+++ b/resources/google-deployments/cromwell.jinja.schema
@@ -54,7 +54,8 @@ properties:
 
     cromwell_version:
       description: Version of cromwell to use.
-      type: number
+      type: string
+      minimum: 60
 
     labels:
       description: Labels to apply to the compute and cloud sql instances.

--- a/resources/google-deployments/cromwell.jinja.schema
+++ b/resources/google-deployments/cromwell.jinja.schema
@@ -16,6 +16,7 @@ required:
 - service_account_email
 - ssh_source_ranges
 - use_vpc_network
+- vpc_cidr
 - zone
 
 properties:
@@ -77,6 +78,11 @@ properties:
       description: Have cromwell use the cromwell net created as the VPC network. This will result in all VMs being placed on this network (instead of default) and they will not have public IPs.
       type: boolean
       default: false
+
+    vpc_cidr:
+      description: ip allocation range for the VPC network cidr notation. Should be a class A private address range, e.g. "10.0.0.0 to 10.255.255.255" .
+      type: string
+      default: 10.10.0.0./16
 
     zone:
       type: string

--- a/resources/google-deployments/cromwell.yaml
+++ b/resources/google-deployments/cromwell.yaml
@@ -23,6 +23,7 @@ resources:
       cromwell_gcs_root:               "gs://<BUCKET_NAME>/cromwell-exeuctions"
 
       use_vpc_network:                  true
+      vpc_cidr:                         10.10.0.0/16
 
       labels: # USED ON DEPLOYMENT ASSESTS, NOT CROMWELL COMPUTE, ADD IN CROMWELL LABELS JSON WHEN SUBMITTING CROMWELL WF
         user:     <USER>

--- a/resources/google-deployments/cromwell.yaml
+++ b/resources/google-deployments/cromwell.yaml
@@ -20,7 +20,7 @@ resources:
       #cromwell_cloudsql_initial_size:  1000
       #cromwell_database_name:          cromwell
       cromwell_cloudsql_password:      <PASSWORD>
-      cromwell_gcs_root:               "gs://<BUCKET_NAME>/cromwell-exeuctions"
+      cromwell_gcs_root:               "gs://<BUCKET_NAME>/cromwell-executions"
 
       use_vpc_network:                  true
       vpc_cidr:                         10.10.0.0/16

--- a/resources/google-deployments/cromwell.yaml
+++ b/resources/google-deployments/cromwell.yaml
@@ -22,6 +22,8 @@ resources:
       cromwell_cloudsql_password:      <PASSWORD>
       cromwell_gcs_root:               "gs://<BUCKET_NAME>/cromwell-exeuctions"
 
+      use_vpc_network:                  true
+
       labels: # USED ON DEPLOYMENT ASSESTS, NOT CROMWELL COMPUTE, ADD IN CROMWELL LABELS JSON WHEN SUBMITTING CROMWELL WF
         user:     <USER>
         project:  <PROJECT>

--- a/resources/startup-scripts/cromwell.py
+++ b/resources/startup-scripts/cromwell.py
@@ -58,14 +58,16 @@ def install_cromwell():
     #curl -OL https://github.com/broadinstitute/cromwell/releases/download/${VERSION}/womtool-${VERSION}.jar && mv womtool-${VERSION}.jar ${JAR_DIR}/
     print("Install cromwell and womtool...")
     import requests, yaml
+    dn_version = CROMWELL_VERSION
+    bn_version = dn_version.replace("_", "-").replace("hotfix-", "")
     os.chdir(JAR_DIR)
     for name in "cromwell", "womtool":
-        print("Install {} version {} ...".format(name, CROMWELL_VERSION))
+        print("Install {0} version {1} ...".format(name, dn_version))
         jar_fn = os.path.join(JAR_DIR, ".".join([name, "jar"]))
         if os.path.exists(jar_fn):
             print("Already installed at {} ...".format(jar_fn))
             continue
-        url = "https://github.com/broadinstitute/cromwell/releases/download/{0}/{1}-{0}.jar".format(CROMWELL_VERSION, name)
+        url = "https://github.com/broadinstitute/cromwell/releases/download/{0}/{1}-{2}.jar".format(dn_version, name, bn_version)
         print("URL {}".format(url))
         response = requests.get(url)
         if not response.ok: raise Exception("GET failed for {}".format(url))
@@ -91,7 +93,7 @@ def install_cromwell_config():
     with open(fn, 'w') as f:
         f.write(papi_template.render(
             cloudsql=params,
-            cromwell_gcs_root=CROMWELL_GCS_ROOT
+            cromwell_gcs_root=CROMWELL_GCS_ROOT,
             project=PROJECT,
             service_account_email=SERVICE_ACCOUNT_EMAIL,
             vpc_network=VPC_NETWORK,

--- a/resources/startup-scripts/cromwell.py
+++ b/resources/startup-scripts/cromwell.py
@@ -8,6 +8,7 @@ CROMWELL_GCS_ROOT='@CROMWELL_GCS_ROOT@'
 SERVICE_ACCOUNT_EMAIL='@SERVICE_ACCOUNT_EMAIL@'
 PROJECT='@PROJECT@'
 VPC_NETWORK='@VPC_NETWORK@'
+VPC_SUBNETWORK='@VPC_SUBNETWORK@'
 
 INSTALL_DIR = os.path.join(os.path.sep, 'opt', 'cromwell')
 JAR_DIR = os.path.join(INSTALL_DIR, "jar")
@@ -97,6 +98,7 @@ def install_cromwell_config():
             project=PROJECT,
             service_account_email=SERVICE_ACCOUNT_EMAIL,
             vpc_network=VPC_NETWORK,
+            vpc_subnetwork=VPC_SUBNETWORK,
             ))
 #-- install_cromwell_config
 

--- a/resources/startup-scripts/cromwell.py
+++ b/resources/startup-scripts/cromwell.py
@@ -7,6 +7,7 @@ CROMWELL_VERSION='@CROMWELL_VERSION@'
 CROMWELL_GCS_ROOT='@CROMWELL_GCS_ROOT@'
 SERVICE_ACCOUNT_EMAIL='@SERVICE_ACCOUNT_EMAIL@'
 PROJECT='@PROJECT@'
+VPC_NETWORK='@VPC_NETWORK@'
 
 INSTALL_DIR = os.path.join(os.path.sep, 'opt', 'cromwell')
 JAR_DIR = os.path.join(INSTALL_DIR, "jar")
@@ -88,10 +89,13 @@ def install_cromwell_config():
     ip = _fetch_instance_info(name='cloudsql-ip')
     params = { "ip": ip, "password": CROMWELL_CLOUDSQL_PASSWORD }
     with open(fn, 'w') as f:
-        f.write( papi_template.render(cloudsql=params,
-                                      project=PROJECT,
-                                      service_account_email=SERVICE_ACCOUNT_EMAIL,
-                                      cromwell_gcs_root=CROMWELL_GCS_ROOT) )
+        f.write(papi_template.render(
+            cloudsql=params,
+            cromwell_gcs_root=CROMWELL_GCS_ROOT
+            project=PROJECT,
+            service_account_email=SERVICE_ACCOUNT_EMAIL,
+            vpc_network=VPC_NETWORK,
+            ))
 #-- install_cromwell_config
 
 def install_cromshell():

--- a/resources/startup-scripts/cromwell.py
+++ b/resources/startup-scripts/cromwell.py
@@ -27,6 +27,8 @@ def install_packages():
         'default-jdk',
         'default-mysql-client-core',
         'git',
+        'jq',
+        'mailutils',
         'python3-pip',
         'python3-dev',
         'python3-setuptools',

--- a/resources/startup-scripts/cromwell.py
+++ b/resources/startup-scripts/cromwell.py
@@ -45,8 +45,8 @@ def install_packages():
         time.sleep(5)
 
     # Python deps
-    import pip
-    pip.main(["install", "jinja2", "pyyaml", "requests>=2.20.0"])
+    from pip._internal import main as pipmain
+    pipmain(["install", "jinja2", "pyyaml", "requests>=2.20.0"])
 
     print("Install pacakges...DONE")
 


### PR DESCRIPTION
Now uses the life sciences API
can use the VPC ability introduced in cromwell v68
upgrade to debian (java 11)
